### PR TITLE
Latest Python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 branches:
   only:
     - master
-notifications:
-  email:
-    - andrew@andrewschaaf.com
 script: "python test.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
-  - "3.7"
+  - "3.7-dev"
+  - "nightly"
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ modules. Next to this it also can perform line-number accurate decompilation.
 
 For a more powerful alternative, take a look at [astor](http://github.com/berkerpeksag/astor).
 
-The library is able to correctly round-trip the python standard library for Python 2.6 up to 3.5.
+The library is able to correctly round-trip the python standard library for Python 2.6 up to 3.7.
 
 ## License
 

--- a/codegen.py
+++ b/codegen.py
@@ -381,11 +381,11 @@ class SourceGenerator(NodeVisitor):
     def visit_AsyncFunctionDef(self, node):
         self.visit_FunctionDef(node, True)
 
-    def visit_FunctionDef(self, node, async=False):
+    def visit_FunctionDef(self, node, async_=False):
         self.newline(extra=1)
         # first decorator line number will be used
         self.decorators(node)
-        if async:
+        if async_:
             self.write('async ')
         self.write('def ')
         self.write(node.name)
@@ -534,9 +534,9 @@ class SourceGenerator(NodeVisitor):
     def visit_AsyncFor(self, node):
         self.visit_For(node, True)
 
-    def visit_For(self, node, async=False):
+    def visit_For(self, node, async_=False):
         self.newline(node, force=True)
-        if async:
+        if async_:
             self.write('async ')
         self.write('for ')
         self.visit_bare(node.target)
@@ -555,9 +555,9 @@ class SourceGenerator(NodeVisitor):
     def visit_AsyncWith(self, node):
         self.visit_With(node, True)
 
-    def visit_With(self, node, async=False):
+    def visit_With(self, node, async_=False):
         self.newline(node, force=True)
-        if async:
+        if async_:
             self.write('async ')
         self.write('with ')
 

--- a/test.py
+++ b/test.py
@@ -61,7 +61,7 @@ class TestCodegen(unittest.TestCase):
         source = ("try:\n"
                   "    l = []\n"
                   "    l[1]\n"
-                  "except IndexError, index_error:\n"
+                  "except IndexError as index_error:\n"
                   "    print index_error")
         self.assertPreserved(source)
 

--- a/test.py
+++ b/test.py
@@ -1,6 +1,9 @@
 import unittest
 import codegen
 import ast
+import sys
+
+PY3 = sys.version_info >= (3, 0)
 
 class TestCodegen(unittest.TestCase):
 
@@ -53,17 +56,22 @@ class TestCodegen(unittest.TestCase):
         self.assertPreserved("del obj.x")
 
     def test_try_expect(self):
+        open_bracket = '('
+        close_bracket = ')'
+        if not PY3:
+            open_bracket = ' '
+            close_bracket = ' '
         source = ("try:\n"
                   "    '#'[2]\n"
                   "except IndexError:\n"
-                  "    print 'What did you expect?!'")
-        self.assertPreserved(source)
+                  "    print{}'What did you expect?!'{}")
+        self.assertPreserved(source.format(open_bracket, close_bracket))
         source = ("try:\n"
                   "    l = []\n"
                   "    l[1]\n"
                   "except IndexError as index_error:\n"
-                  "    print index_error")
-        self.assertPreserved(source)
+                  "    print{}index_error{}")
+        self.assertPreserved(source.format(open_bracket, close_bracket))
 
     def test_import(self):
         self.assertPreserved("import intertools as iterators")


### PR DESCRIPTION
I'm using codegen in my pytest development helper https://github.com/tomviner/pytest-ast-back-to-python (thank you for your extra work on your fork here)

In trying to [fix pytest compat with Python 3.7](https://github.com/pytest-dev/pytest/issues/2818), I wanted to use pytest-ast-back-to-python but codegen fails on 3.6 and 3.7. This PR adds compat with these versions.

I've got the tests passing on my fork: https://travis-ci.org/tomviner/pytest-ast-back-to-python/builds